### PR TITLE
Raise an error if the response is not successful

### DIFF
--- a/lib/purl_fetcher/client.rb
+++ b/lib/purl_fetcher/client.rb
@@ -10,6 +10,11 @@ module PurlFetcher
     require 'purl_fetcher/client/public_xml_record'
     require 'purl_fetcher/client/reader'
     require 'purl_fetcher/client/deletes_reader'
-    # Your code goes here...
+    
+    # General error originating in PurlFetcher::Client
+    class Error < StandardError; end
+
+    # Raised when the response from the server is not successful
+    class ResponseError < Error; end
   end
 end

--- a/spec/purl_fetcher/purl_fetcher_deletes_reader_spec.rb
+++ b/spec/purl_fetcher/purl_fetcher_deletes_reader_spec.rb
@@ -7,13 +7,16 @@ RSpec.describe PurlFetcher::Client::DeletesReader do
   describe '#each' do
     before do
       if defined? JRUBY_VERSION
-        expect(Manticore).to receive(:get).with(%r{/docs/deletes}, query: anything).and_return(double(body: deletes_body))
-        expect(Manticore).to receive(:get).with(%r{/docs/changes}, query: anything).and_return(double(body: changes_body))
+        expect(Manticore).to receive(:get).with(%r{/docs/deletes}, query: anything).and_return(deletes_response)
+        expect(Manticore).to receive(:get).with(%r{/docs/changes}, query: anything).and_return(changes_response)
       else
-        expect(HTTP).to receive(:get).with(%r{/docs/deletes}, params: anything).and_return(double(body: deletes_body))
-        expect(HTTP).to receive(:get).with(%r{/docs/changes}, params: anything).and_return(double(body: changes_body))
+        expect(HTTP).to receive(:get).with(%r{/docs/deletes}, params: anything).and_return(deletes_response)
+        expect(HTTP).to receive(:get).with(%r{/docs/changes}, params: anything).and_return(changes_response)
       end
     end
+
+    let(:deletes_response) { double(body: deletes_body, code: 200) }
+    let(:changes_response) { double(body: changes_body, code: 200) }
 
     let(:deletes_body) {
       {

--- a/spec/purl_fetcher/purl_fetcher_reader_spec.rb
+++ b/spec/purl_fetcher/purl_fetcher_reader_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe PurlFetcher::Client::Reader do
   describe '#each' do
     before do
       if defined? JRUBY_VERSION
-        expect(Manticore).to receive(:get).with(%r{/docs/changes}, query: hash_including(target: 'Searchworks')).and_return(double(body: body))
+        expect(Manticore).to receive(:get).with(%r{/docs/changes}, query: hash_including(target: 'Searchworks')).and_return(response)
       else
-        expect(HTTP).to receive(:get).with(%r{/docs/changes}, params: hash_including(target: 'Searchworks')).and_return(double(body: body))
+        expect(HTTP).to receive(:get).with(%r{/docs/changes}, params: hash_including(target: 'Searchworks')).and_return(response)
       end
     end
+
+    let(:response) { double(body: body, code: 200) }
 
     let(:body) {
       {
@@ -27,16 +29,29 @@ RSpec.describe PurlFetcher::Client::Reader do
     it 'returns objects from the purl-fetcher api' do
       expect(reader.map { |x| x.druid }).to eq ['x', 'y']
     end
-  end
 
-  describe('#collection_members') do
-    before do
-      if defined? JRUBY_VERSION
-        expect(Manticore).to receive(:get).with(%r{/collections/druid:xyz/purls}, query: hash_including(page: 1)).and_return(double(body: body))
-      else
-        expect(HTTP).to receive(:get).with(%r{/collections/druid:xyz/purls}, params: hash_including(page: 1)).and_return(double(body: body))
+    context 'when the status is not successful' do
+      let(:response) {
+        double(body: body, code: 410)
+      }
+      it "raises an error" do
+        expect { reader.map {} }.to raise_error PurlFetcher::Client::Error, 'Unsuccessful response from purl-fetcher'
       end
     end
+  end
+
+  describe '#collection_members' do
+    before do
+      if defined? JRUBY_VERSION
+        expect(Manticore).to receive(:get).with(%r{/collections/druid:xyz/purls}, query: hash_including(page: 1)).and_return(response)
+      else
+        expect(HTTP).to receive(:get).with(%r{/collections/druid:xyz/purls}, params: hash_including(page: 1)).and_return(response)
+      end
+    end
+
+    let(:response) {
+      double(body: body, code: 200)
+    }
 
     let(:body) do
       {


### PR DESCRIPTION
Don't try to JSON.parse a response that may not be JSON. Fixes #12