### PR TITLE
Remove unused mods_display and stanford_mods

### DIFF
--- a/lib/purl_fetcher/client/public_xml_record.rb
+++ b/lib/purl_fetcher/client/public_xml_record.rb
@@ -1,6 +1,4 @@
 require 'nokogiri'
-require 'stanford-mods'
-require 'mods_display'
 require 'dor/rights_auth'
 
 module PurlFetcher::Client
@@ -33,16 +31,6 @@ module PurlFetcher::Client
 
     def get_value(node)
       (node && node.first) ? node.first.content : nil
-    end
-
-    def stanford_mods
-      @smods_rec ||= Stanford::Mods::Record.new.tap do |smods_rec|
-        smods_rec.from_str(mods.to_s)
-      end
-    end
-
-    def mods_display
-      @mods_display ||= ModsDisplay::HTML.new(stanford_mods)
     end
 
     def public_xml

--- a/purl_fetcher-client.gemspec
+++ b/purl_fetcher-client.gemspec
@@ -22,9 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'http'
   spec.add_dependency 'nokogiri'
-  spec.add_dependency 'stanford-mods'
   spec.add_dependency 'dor-rights-auth'
-  spec.add_dependency 'mods_display', '>= 1.0.0.alpha1'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This removes the front end dependencies (view_component, auto-link). There is a companion PR in exhibits: https://github.com/sul-dlss/exhibits/pull/2415