### PR TITLE
Distinguish between not found from other errors in reader.

### DIFF
--- a/lib/purl_fetcher/client.rb
+++ b/lib/purl_fetcher/client.rb
@@ -24,6 +24,9 @@ module PurlFetcher
     # Raised when the response from the server is not successful
     class ResponseError < Error; end
 
+    # Raised when the response from the server indicates that the requested item is not found
+    class NotFoundResponseError < ResponseError; end
+
     include Singleton
     class << self
       def configure(url:, logger: default_logger, token: nil)

--- a/lib/purl_fetcher/client/reader.rb
+++ b/lib/purl_fetcher/client/reader.rb
@@ -11,6 +11,8 @@ class PurlFetcher::Client::Reader
     @range = {}
   end
 
+  # @raise [PurlFetcher::Client::NotFoundResponseError] if item is not found
+  # @raise [PurlFetcher::Client::ResponseError] if the response is not successful
   def collection_members(druid)
     return to_enum(:collection_members, druid) unless block_given?
 
@@ -20,6 +22,8 @@ class PurlFetcher::Client::Reader
   end
 
   # @return [Array<Hash<String,String>>] a list of hashes where the key is a digest and the value is a filepath/filename
+  # @raise [PurlFetcher::Client::NotFoundResponseError] if item is not found
+  # @raise [PurlFetcher::Client::ResponseError] if the response is not successful
   def files_by_digest(druid)
     retrieve_json("/purls/druid:#{druid.delete_prefix('druid:')}", {})
       .fetch("files_by_md5", [])
@@ -36,6 +40,7 @@ class PurlFetcher::Client::Reader
       if defined?(Honeybadger)
         Honeybadger.context({ path:, params:, response_code: response.code, body: response.body })
       end
+      raise PurlFetcher::Client::NotFoundResponseError, "Item not found" if response.status == 404
       raise PurlFetcher::Client::ResponseError, "Unsuccessful response from purl-fetcher"
     end
 

--- a/spec/purl_fetcher/reader_spec.rb
+++ b/spec/purl_fetcher/reader_spec.rb
@@ -60,5 +60,16 @@ RSpec.describe PurlFetcher::Client::Reader do
         expect(reader.files_by_digest('xyz')).to eq([])
       end
     end
+
+    context 'when not found' do
+      before do
+        stub_request(:get, "https://purl-fetcher.stanford.edu/purls/druid:xyz").
+          to_return(status: 404)
+      end
+
+      it 'raises an error' do
+        expect { reader.files_by_digest('xyz') }.to raise_error(PurlFetcher::Client::NotFoundResponseError)
+      end
+    end
   end
 end


### PR DESCRIPTION
DSA needs to treat these cases separately.
