### PR TITLE
Increase timeout

### DIFF
--- a/lib/purl_fetcher/client.rb
+++ b/lib/purl_fetcher/client.rb
@@ -112,7 +112,7 @@ module PurlFetcher
     def default_request_options
       # To allow transfer of large files.
       {
-          read_timeout: 900,
+          read_timeout: 1800, # 30 minutes for first response byte to be received
           timeout: 36000
         }
     end

--- a/lib/purl_fetcher/client/version.rb
+++ b/lib/purl_fetcher/client/version.rb
@@ -1,5 +1,5 @@
 module PurlFetcher
   class Client
-    VERSION = "2.1.0"
+    VERSION = "2.1.1"
   end
 end


### PR DESCRIPTION
We've had an item take take 19 minutes to publish. This PR doubles the time to wait for reading data from purl-fetcher (15 to 30 minutes).
