### PR TITLE
Return full metadata for collection members

### DIFF
--- a/lib/purl_fetcher/client/reader.rb
+++ b/lib/purl_fetcher/client/reader.rb
@@ -11,14 +11,13 @@ class PurlFetcher::Client::Reader
     @range = {}
   end
 
+  # @return [Hash] a hash including member item's druid and release targets
   # @raise [PurlFetcher::Client::NotFoundResponseError] if item is not found
   # @raise [PurlFetcher::Client::ResponseError] if the response is not successful
   def collection_members(druid)
     return to_enum(:collection_members, druid) unless block_given?
 
-    paginated_get("/collections/druid:#{druid.delete_prefix('druid:')}/purls", "purls").each do |obj, _meta|
-      yield obj["druid"].delete_prefix("druid:")
-    end
+    paginated_get("/collections/druid:#{druid.delete_prefix('druid:')}/purls", "purls").each { |member| yield member }
   end
 
   # @return [Array<Hash<String,String>>] a list of hashes where the key is a digest and the value is a filepath/filename

--- a/spec/purl_fetcher/reader_spec.rb
+++ b/spec/purl_fetcher/reader_spec.rb
@@ -21,7 +21,11 @@ RSpec.describe PurlFetcher::Client::Reader do
     end
 
     it 'returns collection members' do
-      expect(reader.collection_members('xyz').to_a).to eq %w[x y z]
+      expect(reader.collection_members('xyz').to_a).to eq [
+        { 'druid' => 'x', 'true_targets' => [ 'Searchworks' ] },
+        { 'druid' => 'y', 'true_targets' => [ 'Searchworks' ] },
+        { 'druid' => 'z', 'true_targets' => [ 'SomethingElse' ] }
+      ]
     end
   end
 


### PR DESCRIPTION
This allows clients to get all the metadata for collection members
instead of just their druid, including release targets and content
types.

Builds on https://github.com/sul-dlss/purl-fetcher/pull/971
Supports https://github.com/sul-dlss/purl/issues/84

If merged, would probably necessitate a new major version bump
for this gem, since it changes a public API. We could then pull
it into exhibits, which is the only consumer I could find
(at https://github.com/sul-dlss/exhibits/blob/a63e8c1fded1687a4b242a1790cdf1dbb0007302/app/models/public_xml_record.rb#L131).
