### PR TITLE
Pass params to Faraday correctly in the PurlFetcher::Client::Reader

### DIFF
--- a/lib/purl_fetcher/client/reader.rb
+++ b/lib/purl_fetcher/client/reader.rb
@@ -33,7 +33,7 @@ class PurlFetcher::Client::Reader
   ##
   # @return [Hash] a parsed JSON hash
   def retrieve_json(path, params)
-    response = conn.get(path, params: params)
+    response = conn.get(path, params)
 
     unless response.success?
       raise PurlFetcher::Client::NotFoundResponseError, "Item not found" if response.status == 404

--- a/spec/purl_fetcher/reader_spec.rb
+++ b/spec/purl_fetcher/reader_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PurlFetcher::Client::Reader do
 
   describe '#collection_members' do
     before do
-      stub_request(:get, "https://purl-fetcher.stanford.edu/collections/druid:xyz/purls?params%5Bpage%5D=1&params%5Bper_page%5D=1000").
+      stub_request(:get, "https://purl-fetcher.stanford.edu/collections/druid:xyz/purls?page=1&per_page=1000").
         to_return(status: 200, body:, headers: { 'content-type' => 'application/json' })
     end
 


### PR DESCRIPTION
Fixes #61

This passes the parameters to append to the request to Faraday
in the correct way – as a second parameter, rather than a hash with
key 'params'.

The latter approach resulted in the params being rendered at the
literal key 'params', which encoded and collapsed all of them
inside the URL, and as a result purl-fetcher did not interpret them.

This in turn caused pagination to not work because we were always
requesting the same page of results over and over again.

The presence of a test that stubs the params in this way seems to
suggest that purl-fetcher's API once might have worked this way,
but it no longer does.