### PR TITLE
Add a method for fetching items released to a target

### DIFF
--- a/lib/purl_fetcher/client/reader.rb
+++ b/lib/purl_fetcher/client/reader.rb
@@ -20,6 +20,13 @@ class PurlFetcher::Client::Reader
     paginated_get("/collections/druid:#{druid.delete_prefix('druid:')}/purls", "purls").each { |member| yield member }
   end
 
+  # @return [Hash] a hash including the item's druid and its last updated time
+  def released_to(target)
+    return to_enum(:released_to, ERB::Util.url_encode(target)) unless block_given?
+
+    retrieve_json("/released/#{target}").each { |item| yield item }
+  end
+
   # @return [Array<Hash<String,String>>] a list of hashes where the key is a digest and the value is a filepath/filename
   # @raise [PurlFetcher::Client::NotFoundResponseError] if item is not found
   # @raise [PurlFetcher::Client::ResponseError] if the response is not successful
@@ -32,7 +39,7 @@ class PurlFetcher::Client::Reader
 
   ##
   # @return [Hash] a parsed JSON hash
-  def retrieve_json(path, params)
+  def retrieve_json(path, params = {})
     response = conn.get(path, params)
 
     unless response.success?

--- a/spec/purl_fetcher/reader_spec.rb
+++ b/spec/purl_fetcher/reader_spec.rb
@@ -29,6 +29,27 @@ RSpec.describe PurlFetcher::Client::Reader do
     end
   end
 
+  describe '#released_to' do
+    before do
+      stub_request(:get, "https://purl-fetcher.stanford.edu/released/Searchworks").
+        to_return(status: 200, body:, headers: { 'content-type' => 'application/json' })
+    end
+
+    let(:body) do
+      [
+        { druid: 'druid:abc123', last_updated: '2023-10-01T12:00:00Z' },
+        { druid: 'druid:def456', last_updated: '2023-10-02T12:00:00Z' }
+      ].to_json
+    end
+
+    it 'returns items released to the target' do
+      expect(reader.released_to('Searchworks').to_a).to eq [
+        { 'druid' => 'druid:abc123', 'last_updated' => '2023-10-01T12:00:00Z' },
+        { 'druid' => 'druid:def456', 'last_updated' => '2023-10-02T12:00:00Z' }
+      ]
+    end
+  end
+
   describe '#files_by_digest' do
     before do
       stub_request(:get, "https://purl-fetcher.stanford.edu/v1/purls/druid:xyz").


### PR DESCRIPTION
This route exists in purl-fetcher but didn't have an associated
method yet. It is currently used by PURL's sitemap generator and
may be used by DataWorks in the future.
